### PR TITLE
Fixed first display of worth being incorrect

### DIFF
--- a/gamemodes/zombiesurvival/gamemode/init.lua
+++ b/gamemodes/zombiesurvival/gamemode/init.lua
@@ -1451,6 +1451,10 @@ function GM:PlayerReadyRound(pl)
 
 	local classid = pl:GetZombieClass()
 	pl:SetZombieClass(classid, true, pl)
+	
+	if self.OverrideStartingWorth then
+		pl:SendLua("GAMEMODE.StartingWorth="..tostring(self.StartingWorth))
+	end
 
 	if pl:Team() == TEAM_UNDEAD then
 		-- This is just so they get updated on what class they are and have their hulls set up right.
@@ -1464,10 +1468,6 @@ function GM:PlayerReadyRound(pl)
 	if self.RoundEnded then
 		pl:SendLua("gamemode.Call(\"EndRound\", "..tostring(ROUNDWINNER)..", \""..game.GetMapNext().."\")")
 		gamemode.Call("DoHonorableMentions", pl)
-	end
-
-	if self.OverrideStartingWorth then
-		pl:SendLua("GAMEMODE.StartingWorth="..tostring(self.StartingWorth))
 	end
 
 	if pl:GetInfo("zs_noredeem") == "1" then


### PR DESCRIPTION
Changed order of player's variable assignments so that StartingWorth is set before being displayed for the first time.
