### PR TITLE
fixed being able to pickup pistol ammo anytime

### DIFF
--- a/gamemodes/zombiesurvival/entities/weapons/weapon_zs_fists.lua
+++ b/gamemodes/zombiesurvival/entities/weapons/weapon_zs_fists.lua
@@ -22,6 +22,9 @@ SWEP.NoMagazine = true
 SWEP.Undroppable = true
 SWEP.NoPickupNotification = true
 
+SWEP.Primary.Ammo = "none"
+SWEP.Secondary.Ammo = "none"
+
 local SwingSound = Sound( "weapons/slam/throw.wav" )
 local HitSound = Sound( "Flesh.ImpactHard" )
 


### PR DESCRIPTION
Gave fists an ammo type so that the check made GAMEMODE.weaponrequiredforammo can function as intended.
