### PR TITLE
Fixed player health display.

### DIFF
--- a/gamemodes/zombiesurvival/gamemode/vgui/zshealtharea.lua
+++ b/gamemodes/zombiesurvival/gamemode/vgui/zshealtharea.lua
@@ -10,7 +10,7 @@ local function ContentsPaint(self)
 		colHealth.r = (1 - healthperc) * 180
 		colHealth.g = healthperc * 180
 
-		draw.SimpleTextBlurry(health, "ZSHUDFont", 8, self:GetTall() - 8, colHealth, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
+		draw.SimpleTextBlurry(health, "ZSHUDFont", 8, self:GetTall() - draw.GetFontHeight("ZSHUDFont"), colHealth, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
 	end
 end
 


### PR DESCRIPTION
Player health display has been broken since the update on Feb 22, 2016. This patch places it in the proper position.