### PR TITLE
Various fixes for Zombie Escape mode

### DIFF
--- a/gamemodes/zombiesurvival/entities/entities/math_counter.lua
+++ b/gamemodes/zombiesurvival/entities/entities/math_counter.lua
@@ -59,29 +59,26 @@ function ENT:AcceptInput( name, activator, caller, data )
 	Msg("\tCaller: " .. tostring(caller) .. (caller:IsValid() and "("..caller:GetName()..")" or "") .. "\n")
 	Msg("\tData: " .. tostring(data) .. "\n")]]
 
-	local inputdata = {
-		name = name,
-		pActivator = activator,
-		pCaller = caller,
-		value = data
-	}
-
 	name = string.lower(name)
 
 	local inputActionFunc = self.InputDispatch[name]
-	local returnValue
 
 	if isfunction(inputActionFunc) then
-		returnValue = inputActionFunc(self, inputdata)
+		local inputdata = {
+			name = name,
+			pActivator = activator,
+			pCaller = caller,
+			value = data
+		}
+
+		inputActionFunc(self, inputdata)
+
+		self:PostAcceptInput(name, activator, caller, data)
+
+		return true
 	end
 
-	self:PostAcceptInput(name, activator, caller, data)
-
-	if returnValue then
-		return tobool(returnValue)
-	end
-
-	return true
+	return false
 end
 
 function ENT:PostAcceptInput(name, activator, caller, data)

--- a/gamemodes/zombiesurvival/entities/entities/math_counter.lua
+++ b/gamemodes/zombiesurvival/entities/entities/math_counter.lua
@@ -5,7 +5,6 @@ ENT.InputDispatch = {}
 ENT.EventQueue = {}
 
 function ENT:Initialize()
-	-- Any better way I should be doing this?
 	if !self.m_OutValue then self.m_OutValue = 0 end
 	if !self.m_flMin then self.m_flMin = 0 end
 	if !self.m_flMax then self.m_flMax = 0 end
@@ -91,24 +90,17 @@ function ENT:PostAcceptInput(name, activator, caller, data)
 		self.m_InitialValue = self.m_OutValue
 	end
 	
-	-- Update boss values, but don't send clamped min value
 	if !self.m_LastValue || self.m_LastValue != self.m_OutValue then
 		hook.Call("MathCounterUpdate", GAMEMODE, self, activator)
 	end
 	
 	if self.m_bHitMin then
 		hook.Call("MathCounterHitMin", GAMEMODE, self, activator)
+	elseif self.m_bHitMax then
+		hook.Call("MathCounterHitMax", GAMEMODE, self, activator)
 	end
 
 	self.m_LastValue = self.m_OutValue
-	
-	/*if !self.m_InitialValue || self.m_InitialValue < self:GetOutValue() then -- starting health
-		self.m_InitialValue = self:GetOutValue()
-		hook.Call("MathCounterUpdate", GAMEMODE, self, activator)
-	elseif self.m_LastValue < self:GetOutValue() then -- health was added
-		self.m_InitialValue = self:GetOutValue()
-		hook.Call("MathCounterUpdate", GAMEMODE, self, activator)
-	end*/
 end
 
 function ENT:InputSetHitMax(inputdata)
@@ -187,7 +179,7 @@ function ENT:InputSetValueNoFire(inputdata)
 		flNewValue = math.Clamp(flNewValue, self.m_flMin, self.m_flMax)
 	end
 
-	self:UpdateOutValue( inputdata.pActivator, flNewValue, true )
+	self.m_OutValue = flNewValue
 end
 
 function ENT:InputSubtract(inputdata)
@@ -212,7 +204,7 @@ function ENT:InputDisable(inputdata)
 	self.m_bDisabled = true
 end
 
-function ENT:UpdateOutValue(pActivator, fNewValue, bNoOutput)
+function ENT:UpdateOutValue(pActivator, fNewValue)
 	if !fNewValue then
 		ErrorNoHalt("Math Counter " .. self:GetName() .. " received new out value which was nil (activator="..tostring(pActivator)..").\n")
 		debug.Trace()
@@ -243,15 +235,12 @@ function ENT:UpdateOutValue(pActivator, fNewValue, bNoOutput)
 		fNewValue = math.Clamp(fNewValue, self.m_flMin, self.m_flMax)
 	end
 
-	self:SetOutValue(fNewValue, pActivator, bNoOutput)
+	self:SetOutValue(fNewValue, pActivator)
 end
 
-function ENT:SetOutValue(fNewValue, pActivator, bNoOutput)
+function ENT:SetOutValue(fNewValue, pActivator)
 	self.m_OutValue = fNewValue
-
-	if !bNoOutput then
-		self:QueueTriggerOutput("OutValue", pActivator, self.m_OutValue)
-	end
+	self:QueueTriggerOutput("OutValue", pActivator, self.m_OutValue)
 end
 
 function ENT:GetOutValue()

--- a/gamemodes/zombiesurvival/entities/entities/math_counter.lua
+++ b/gamemodes/zombiesurvival/entities/entities/math_counter.lua
@@ -1,0 +1,298 @@
+ENT.Base = "base_point"
+ENT.Type = "point"
+
+ENT.InputDispatch = {}
+ENT.EventQueue = {}
+
+function ENT:Initialize()
+	-- Any better way I should be doing this?
+	if !self.m_OutValue then self.m_OutValue = 0 end
+	if !self.m_flMin then self.m_flMin = 0 end
+	if !self.m_flMax then self.m_flMax = 0 end
+
+	-- Make sure max and min are ordered properly or clamp won't work.
+	if self.m_flMin > self.m_flMax then
+		local flTemp = self.m_flMax
+		self.m_flMax = self.m_flMin
+		self.m_flMin = flTemp
+	end
+	
+	-- Clamp initial value to within the valid range.
+	if ((self.m_flMin != 0) || (self.m_flMax != 0)) then
+		local flStartValue = math.Clamp(self.m_OutValue, self.m_flMin, self.m_flMax)
+		self.m_OutValue = flStartValue
+	end
+	
+	self.m_bHitMin = false
+	self.m_bHitMax = false
+	
+	self.m_bDisabled = false
+end
+
+function ENT:DefineInputFunc( name, func )
+	name = string.lower(name)
+	self.InputDispatch[name] = func
+end
+
+function ENT:KeyValue( key, value )
+
+	local lkey = string.lower(key)
+
+	-- Set the initial value of the counter.
+	if lkey == "startvalue" then
+		self.m_OutValue = tonumber(value)
+		return true
+	elseif lkey == "min" then
+		self.m_flMin = tonumber(value)
+	elseif lkey == "max" then
+		self.m_flMax = tonumber(value)
+	end
+
+	self:StoreOutput( key, value )
+
+end
+
+function ENT:AcceptInput( name, activator, caller, data )
+	--[[Msg("MATH COUNTER INPUT:\n")
+	Msg("\tSelf: " .. tostring(self) .. " ("..self:GetName()..")" .. "\n")
+	Msg("\tName: " .. tostring(name) .. "\n")
+	Msg("\tActivator: " .. tostring(activator) .. "\n")
+	Msg("\tCaller: " .. tostring(caller) .. (caller:IsValid() and "("..caller:GetName()..")" or "") .. "\n")
+	Msg("\tData: " .. tostring(data) .. "\n")]]
+
+	local inputdata = {
+		name = name,
+		pActivator = activator,
+		pCaller = caller,
+		value = data
+	}
+
+	name = string.lower(name)
+
+	local inputActionFunc = self.InputDispatch[name]
+	local returnValue
+
+	if isfunction(inputActionFunc) then
+		returnValue = inputActionFunc(self, inputdata)
+	end
+
+	self:PostAcceptInput(name, activator, caller, data)
+
+	if returnValue then
+		return tobool(returnValue)
+	end
+
+	return true
+end
+
+function ENT:PostAcceptInput(name, activator, caller, data)
+	-- Setup initial value
+	if !self.m_InitialValue || self.m_InitialValue < self.m_OutValue then
+		self.m_InitialValue = self.m_OutValue
+	end
+	
+	-- Update boss values, but don't send clamped min value
+	if !self.m_LastValue || self.m_LastValue != self.m_OutValue then
+		hook.Call("MathCounterUpdate", GAMEMODE, self, activator)
+	end
+	
+	if self.m_bHitMin then
+		hook.Call("MathCounterHitMin", GAMEMODE, self, activator)
+	end
+
+	self.m_LastValue = self.m_OutValue
+	
+	/*if !self.m_InitialValue || self.m_InitialValue < self:GetOutValue() then -- starting health
+		self.m_InitialValue = self:GetOutValue()
+		hook.Call("MathCounterUpdate", GAMEMODE, self, activator)
+	elseif self.m_LastValue < self:GetOutValue() then -- health was added
+		self.m_InitialValue = self:GetOutValue()
+		hook.Call("MathCounterUpdate", GAMEMODE, self, activator)
+	end*/
+end
+
+function ENT:InputSetHitMax(inputdata)
+	self.m_flMax = tonumber(inputdata.value)
+
+	if ( self.m_flMax < self.m_flMin ) then
+		self.m_flMin = self.m_flMax
+	end
+
+	self:UpdateOutValue(inputdata.pActivator, self.m_OutValue)
+end
+
+function ENT:InputSetHitMin(inputdata)
+	self.m_flMin = tonumber(inputdata.value)
+
+	if ( self.m_flMax < self.m_flMin ) then
+		self.m_flMax = self.m_flMin
+	end
+
+	self:UpdateOutValue(inputdata.pActivator, self.m_OutValue)
+end
+
+function ENT:InputAdd(inputdata)
+	if( self.m_bDisabled ) then
+		Msg("Math Counter "..self:GetName().." ignoring ADD because it is disabled\n")
+		return
+	end
+
+	local fNewValue = self.m_OutValue + tonumber(inputdata.value)
+	self:UpdateOutValue( inputdata.pActivator, fNewValue )
+end
+
+function ENT:InputDivide(inputdata)
+	if( self.m_bDisabled ) then
+		Msg("Math Counter "..self:GetName().." ignoring DIVIDE because it is disabled\n")
+		return
+	end
+
+	local flValue = tonumber(inputdata.value)
+	if (flValue != 0) then
+		local fNewValue = self.m_OutValue / flValue
+		self:UpdateOutValue( inputdata.pActivator, fNewValue )
+	else
+		ErrorNoHalt("LEVEL DESIGN ERROR: Divide by zero in math_value\n")
+		self:UpdateOutValue( inputdata.pActivator, self.m_OutValue )
+	end
+end
+
+function ENT:InputMultiply(inputdata)
+	if( self.m_bDisabled ) then
+		Msg("Math Counter "..self:GetName().." ignoring MULTIPLY because it is disabled\n")
+		return
+	end
+
+	local fNewValue = self.m_OutValue * tonumber(inputdata.value)
+	self:UpdateOutValue( inputdata.pActivator, fNewValue )
+end
+
+function ENT:InputSetValue(inputdata)
+	if( self.m_bDisabled ) then
+		Msg("Math Counter "..self:GetName().." ignoring SETVALUE because it is disabled\n")
+		return
+	end
+
+	self:UpdateOutValue( inputdata.pActivator, tonumber(inputdata.value) )
+end
+
+function ENT:InputSetValueNoFire(inputdata)
+	if( self.m_bDisabled ) then
+		Msg("Math Counter "..self:GetName().." ignoring SETVALUENOFIRE because it is disabled\n")
+		return
+	end
+
+	local flNewValue = tonumber(inputdata.value)
+	if (( self.m_flMin != 0 ) || (self.m_flMax != 0 )) then
+		flNewValue = math.Clamp(flNewValue, self.m_flMin, self.m_flMax)
+	end
+
+	self:UpdateOutValue( inputdata.pActivator, flNewValue, true )
+end
+
+function ENT:InputSubtract(inputdata)
+	if( self.m_bDisabled ) then
+		Msg("Math Counter "..self:GetName().." ignoring SUBTRACT because it is disabled\n")
+		return
+	end
+
+	local fNewValue = self.m_OutValue - tonumber(inputdata.value)
+	self:UpdateOutValue( inputdata.pActivator, fNewValue )
+end
+
+function ENT:InputGetValue(inputdata)
+	self:QueueTriggerOutput("OnGetValue", inputdata.pActivator, self.m_OutValue)
+end
+
+function ENT:InputEnable(inputdata)
+	self.m_bDisabled = false
+end
+
+function ENT:InputDisable(inputdata)
+	self.m_bDisabled = true
+end
+
+function ENT:UpdateOutValue(pActivator, fNewValue, bNoOutput)
+	if !fNewValue then
+		ErrorNoHalt("Math Counter " .. self:GetName() .. " received new out value which was nil (activator="..tostring(pActivator)..").\n")
+		debug.Trace()
+		fNewValue = 0
+	end
+
+	if ((self.m_flMin != 0) || (self.m_flMax != 0)) then
+		-- Fire an output any time we reach or exceed our maximum value.
+		if ( fNewValue >= self.m_flMax ) then
+			if ( !self.m_bHitMax ) then
+				self.m_bHitMax = true
+				self:QueueTriggerOutput("OnHitMax", pActivator)
+			end
+		else
+			self.m_bHitMax = false
+		end
+
+		-- Fire an output any time we reach or go below our minimum value.
+		if ( fNewValue <= self.m_flMin ) then
+			if ( !self.m_bHitMin ) then
+				self.m_bHitMin = true
+				self:QueueTriggerOutput("OnHitMin", pActivator)
+			end
+		else
+			self.m_bHitMin = false
+		end
+
+		fNewValue = math.Clamp(fNewValue, self.m_flMin, self.m_flMax)
+	end
+
+	self:SetOutValue(fNewValue, pActivator, bNoOutput)
+end
+
+function ENT:SetOutValue(fNewValue, pActivator, bNoOutput)
+	self.m_OutValue = fNewValue
+
+	if !bNoOutput then
+		self:QueueTriggerOutput("OutValue", pActivator, self.m_OutValue)
+	end
+end
+
+function ENT:GetOutValue()
+	return self.m_OutValue
+end
+
+function ENT:UpdateTransmitState()
+	return TRANSMIT_NEVER
+end
+
+function ENT:QueueTriggerOutput( name, activator, data )
+	table.insert(self.EventQueue, {self,name,activator, data})
+end
+
+ENT:DefineInputFunc("Add", ENT.InputAdd)
+ENT:DefineInputFunc("Divide", ENT.InputDivide)
+ENT:DefineInputFunc("Multiply", ENT.InputMultiply)
+ENT:DefineInputFunc("SetValue", ENT.InputSetValue)
+ENT:DefineInputFunc("SetValueNoFire", ENT.InputSetValueNoFire)
+ENT:DefineInputFunc("Subtract", ENT.InputSubtract)
+ENT:DefineInputFunc("SetHitMax", ENT.InputSetHitMax)
+ENT:DefineInputFunc("SetHitMin", ENT.InputSetHitMin)
+ENT:DefineInputFunc("GetValue", ENT.InputGetValue)
+ENT:DefineInputFunc("Enable", ENT.InputEnable)
+ENT:DefineInputFunc("Disable", ENT.InputDisable)
+
+--
+-- Reproduce Source Engine's `g_EventQueue` behavior. GMod fires trigger 
+-- outputs immediately while the Source Engine queues them to fire on the 
+-- next frame.
+--
+local EventQueue = ENT.EventQueue
+
+local function EventQueueThink()
+	while #EventQueue > 0 do
+		local event = table.remove(EventQueue, 1)
+		local ent = table.remove(event, 1)
+
+		if IsValid(ent) then
+			ent:TriggerOutput(unpack(event))
+		end
+	end
+end
+hook.Add("Think", "ProcessCounterEventQueue", EventQueueThink)

--- a/gamemodes/zombiesurvival/entities/weapons/weapon_map_base/shared.lua
+++ b/gamemodes/zombiesurvival/entities/weapons/weapon_map_base/shared.lua
@@ -24,6 +24,8 @@ SWEP.WorldModel	= ""
 SWEP.WalkSpeed = SPEED_NORMAL
 
 function SWEP:Initialize()
+	self:AddSolidFlags(FSOLID_TRIGGER) -- Nothing collides with these but it gets touches
+	self:UseTriggerBounds(true, 30)
 end
 
 function SWEP:SetWeaponHoldType()

--- a/gamemodes/zombiesurvival/entities/weapons/weapon_zs_base/shared.lua
+++ b/gamemodes/zombiesurvival/entities/weapons/weapon_zs_base/shared.lua
@@ -235,7 +235,20 @@ function SWEP:ShootBullets(dmg, numbul, cone)
 	owner:DoAttackEvent()
 
 	self:StartBulletKnockback()
-	owner:FireBullets({Num = numbul, Src = owner:GetShootPos(), Dir = owner:GetAimVector(), Spread = Vector(cone, cone, 0), Tracer = 1, TracerName = self.TracerName, Force = dmg * 0.1, Damage = dmg, Callback = self.BulletCallback})
+
+	owner:FireBullets({
+		Num = numbul,
+		Src = owner:GetShootPos(),
+		Dir = owner:GetAimVector(),
+		Spread = Vector(cone, cone, 0),
+		Tracer = 1,
+		TracerName = self.TracerName,
+		AmmoType = self.Primary.Ammo,
+		Force = dmg * 0.1,
+		Damage = dmg,
+		Callback = self.BulletCallback
+	})
+
 	self:DoBulletKnockback(self.Primary.KnockbackScale * 0.05)
 	self:EndBulletKnockback()
 end

--- a/gamemodes/zombiesurvival/entities/weapons/weapon_zs_base/shared.lua
+++ b/gamemodes/zombiesurvival/entities/weapons/weapon_zs_base/shared.lua
@@ -240,7 +240,7 @@ function SWEP:ShootBullets(dmg, numbul, cone)
 		Num = numbul,
 		Src = owner:GetShootPos(),
 		Dir = owner:GetAimVector(),
-		Spread = Vector(cone, cone, 0),
+		Spread = Vector(cone, cone, cone),
 		Tracer = 1,
 		TracerName = self.TracerName,
 		AmmoType = self.Primary.Ammo,

--- a/gamemodes/zombiesurvival/gamemode/init.lua
+++ b/gamemodes/zombiesurvival/gamemode/init.lua
@@ -2284,6 +2284,9 @@ function GM:EntityTakeDamage(ent, dmginfo)
 
 	if ent:IsPlayer() then
 		dispatchdamagedisplay = true
+	elseif self.ZombieEscape then
+		-- stop here, remaining rules break boss-related entities which shouldn't
+		-- be destroyed
 	elseif ent.PropHealth then -- A prop that was invulnerable and converted to vulnerable.
 		if self.NoPropDamageFromHumanMelee and attacker:IsPlayer() and attacker:Team() == TEAM_HUMAN and inflictor.IsMelee then
 			dmginfo:SetDamage(0)

--- a/gamemodes/zombiesurvival/gamemode/init.lua
+++ b/gamemodes/zombiesurvival/gamemode/init.lua
@@ -26,6 +26,7 @@ AddCSLuaFile("sh_zombieclasses.lua")
 AddCSLuaFile("sh_animations.lua")
 AddCSLuaFile("sh_sigils.lua")
 AddCSLuaFile("sh_channel.lua")
+AddCSLuaFile("sh_bullets.lua")
 
 AddCSLuaFile("cl_draw.lua")
 AddCSLuaFile("cl_util.lua")

--- a/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
+++ b/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
@@ -882,7 +882,7 @@ function meta:GetRight()
 	return self:SyncAngles():Right()
 end
 
-meta.OldFireBullets = FindMetaTable("Player").FireBullets
+meta.OldFireBullets = FindMetaTable("Entity").FireBullets
 function meta:FireBullets(bulletInfo, suppressHostEvents)
 	if not GAMEMODE.ZombieEscape then
 		self:OldFireBullets(bulletInfo, suppressHostEvents)

--- a/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
+++ b/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
@@ -881,3 +881,29 @@ end
 function meta:GetRight()
 	return self:SyncAngles():Right()
 end
+
+meta.OldFireBullets = FindMetaTable("Player").FireBullets
+function meta:FireBullets(bulletInfo, suppressHostEvents)
+	if not GAMEMODE.ZombieEscape then
+		self:OldFireBullets(bulletInfo, suppressHostEvents)
+		return
+	end
+
+	if not IsFirstTimePredicted() then return end
+
+	math.randomseed( CurTime() )
+
+	-- Fire bullets, calculate impacts & effects	
+	if SERVER and not self:IsListenServerHost() then
+		self:LagCompensation( true )
+	end
+	
+	for i = 1, bulletInfo.Num do
+		self:FireCSSBullet(bulletInfo)
+	end
+
+	if SERVER and not self:IsListenServerHost() then
+		self:LagCompensation( false )
+	end
+
+end

--- a/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
+++ b/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
@@ -884,26 +884,9 @@ end
 
 meta.OldFireBullets = FindMetaTable("Player").FireBullets
 function meta:FireBullets(bulletInfo, suppressHostEvents)
-	if not GAMEMODE.ZombieEscape then
-		self:OldFireBullets(bulletInfo, suppressHostEvents)
-		return
-	end
-
-	if not IsFirstTimePredicted() then return end
-
 	math.randomseed( CurTime() )
-
-	-- Fire bullets, calculate impacts & effects	
-	if SERVER and not self:IsListenServerHost() then
-		self:LagCompensation( true )
-	end
 	
 	for i = 1, bulletInfo.Num do
-		self:FireCSSBullet(bulletInfo)
+		self:FireCSSBullet(bulletInfo, suppressHostEvents)
 	end
-
-	if SERVER and not self:IsListenServerHost() then
-		self:LagCompensation( false )
-	end
-
 end

--- a/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
+++ b/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
@@ -884,9 +884,26 @@ end
 
 meta.OldFireBullets = FindMetaTable("Player").FireBullets
 function meta:FireBullets(bulletInfo, suppressHostEvents)
+	if not GAMEMODE.ZombieEscape then
+		self:OldFireBullets(bulletInfo, suppressHostEvents)
+		return
+	end
+
+	if not IsFirstTimePredicted() then return end
+
+	local lagCompensation = SERVER and not self:IsListenServerHost()
+
 	math.randomseed( CurTime() )
 	
+	if lagCompensation then
+		self:LagCompensation(true)
+	end
+
 	for i = 1, bulletInfo.Num or 1 do
 		self:FireCSSBullet(bulletInfo, suppressHostEvents)
 	end
+
+	if lagCompensation then
+		self:LagCompensation(false)
+	end 
 end

--- a/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
+++ b/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
@@ -886,7 +886,7 @@ meta.OldFireBullets = FindMetaTable("Player").FireBullets
 function meta:FireBullets(bulletInfo, suppressHostEvents)
 	math.randomseed( CurTime() )
 	
-	for i = 1, bulletInfo.Num do
+	for i = 1, bulletInfo.Num or 1 do
 		self:FireCSSBullet(bulletInfo, suppressHostEvents)
 	end
 end

--- a/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
@@ -184,10 +184,10 @@ local function TraceToExit( trace )
 	return false
 end
 
-function playerMeta:MakeTracer( vecStart, vecEnd, tracerName )
+function playerMeta:MakeTracer( vecStart, vecEnd, tracerName, tracerCount )
 
 	-- Only show every 4 bullets
-	if self.BulletCount and self.BulletCount < 4 then
+	if self.BulletCount and self.BulletCount < (tracerCount or 4) then
 		self.BulletCount = self.BulletCount + 1
 		return
 	else
@@ -349,13 +349,13 @@ function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
 				end
 			end
 
-			self:MakeTracer( tr.StartPos, tr.HitPos, bulletInfo.TracerName )
+			self:MakeTracer( tr.StartPos, tr.HitPos, bulletInfo.TracerName, bulletInfo.Tracer or 1 )
 
 		end
 
 		if SERVER then
 			local dmginfo = DamageInfo()
-			dmginfo:SetAttacker(self)
+			dmginfo:SetAttacker(bulletInfo.Attacker or self)
 			dmginfo:SetInflictor(weap)
 			dmginfo:SetDamage(fCurrentDamage)
 			dmginfo:SetDamageType(iDamageType)
@@ -364,7 +364,7 @@ function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
 			local vecForce = vecDir:GetNormal()
 			-- vecForce = vecForce * 1 -- Ammo Damage Force
 			vecForce = vecForce * phys_pushscale:GetFloat()
-			-- vecForce = vecForce * 1 -- scale
+			vecForce = vecForce * (bulletInfo.Force or 1)
 			dmginfo:SetDamageForce(vecForce)
 
 			tr.Entity:DispatchTraceAttack(dmginfo, tr.StartPos, tr. HitPos, vecDir)

--- a/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
@@ -236,7 +236,7 @@ function playerMeta:MakeTracer( vecStart, vecEnd, tracerName, tracerCount )
 
 end
 
-local r_drawtracers_firstperson = CreateConVar( "r_drawtracers_firstperson", 0, 0, "" )
+local r_drawtracers_firstperson = CreateConVar( "r_drawtracers_firstperson", 0, FCVAR_CHEAT, "" )
 local debugTracerBounds = Vector(2,2,2)
 
 local function DrawDebugTracer( tr )
@@ -270,9 +270,11 @@ function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
 	local fCurrentDamage = iDamage
 	local flCurrentDistance = 0.0
 
-	local vecDirShooting = shootAngles:Angle():Forward()
-	local vecRight = shootAngles:Angle():Right()
-	local vecUp = shootAngles:Angle():Up()
+	shootAngles = shootAngles:Angle()
+
+	local vecDirShooting = shootAngles:Forward()
+	local vecRight = shootAngles:Right()
+	local vecUp = shootAngles:Up()
 
 	local weap = self:GetActiveWeapon()
 	if not IsValid(weap) then return end

--- a/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
@@ -367,6 +367,12 @@ function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
 			vecForce = vecForce * (bulletInfo.Force or 1)
 			dmginfo:SetDamageForce(vecForce)
 
+			if tr.Entity:IsPlayer() then
+				hook.Run( "ScalePlayerDamage", tr.Entity, tr.HitGroup, dmginfo )
+			elseif tr.Entity:IsNPC() then
+				hook.Run( "ScaleNPCDamage", tr.Entity, tr.HitGroup, dmginfo )
+			end
+
 			tr.Entity:DispatchTraceAttack(dmginfo, tr.StartPos, tr. HitPos, vecDir)
 
 			-- TODO: TraceAttackToTriggers

--- a/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
@@ -64,6 +64,7 @@ function util.Tracer( vecStart, vecEnd, iEntIndex, iAttachment, flVelocity, pCus
 end
 
 local BulletTypeParameters = {
+	-- CS
 	ammo_50AE = {
 		fPenetrationPower 		= 30,
 		flPenetrationDistance 	= 1000,
@@ -104,6 +105,29 @@ local BulletTypeParameters = {
 		fPenetrationPower 		= 30,
 		flPenetrationDistance 	= 2000,
 	},
+
+	-- GMod
+	ar2 = {
+		fPenetrationPower 		= 20,
+		flPenetrationDistance 	= 800,
+	},
+	SniperRound = {
+		fPenetrationPower 		= 39,
+		flPenetrationDistance 	= 5000,
+	},
+	["357"] = {
+		fPenetrationPower 		= 25,
+		flPenetrationDistance 	= 800,
+	},
+	pistol = {
+		fPenetrationPower 		= 21,
+		flPenetrationDistance 	= 800,
+	},
+	smg1 = {
+		fPenetrationPower 		= 30,
+		flPenetrationDistance 	= 2000,
+	},
+
 	default = {
 		fPenetrationPower 		= 0,
 		flPenetrationDistance 	= 0,
@@ -210,6 +234,14 @@ function playerMeta:MakeTracer( vecStart, vecEnd, tracerName, tracerCount )
 
 	util.Effect( tracerName or "Tracer", data )
 
+end
+
+local r_drawtracers_firstperson = CreateConVar( "r_drawtracers_firstperson", 0, 0, "" )
+local debugTracerBounds = Vector(2,2,2)
+
+local function DrawDebugTracer( tr )
+	debugoverlay.Box(tr.HitPos, -debugTracerBounds, debugTracerBounds, 10, COLOR_RED)
+	debugoverlay.Line(tr.StartPos, tr.HitPos, 10, COLOR_RED, false)
 end
 
 local phys_pushscale = GetConVar( "phys_pushscale" )
@@ -369,6 +401,10 @@ function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
 			tr.Entity:DispatchTraceAttack(dmginfo, tr.StartPos, tr.HitPos, vecDir)
 
 			-- TODO: TraceAttackToTriggers
+		end
+
+		if CLIENT or self:IsListenServerHost() and r_drawtracers_firstperson:GetBool() then
+			DrawDebugTracer(tr)
 		end
 
 		if iPenetration == 0 and !hitGrate then

--- a/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
@@ -1,0 +1,445 @@
+-- Code taken from Breakpoint servers CS:S gamemode
+-- https://bitbucket.org/blackops7799/breakpoint/src/bb3393586a30b99e399feca8e0d6d9e5a6fda2fc/gamemodes/css/gamemode/sh_bullets.lua
+
+local playerMeta = FindMetaTable("Player")
+if not playerMeta then return end
+
+local cTakeDamageInfoMeta = FindMetaTable("CTakeDamageInfo")
+if not cTakeDamageInfoMeta then return end
+
+function util.ImpactTrace( ply, tr, iDamageType, pCustomImpactName, effect )
+	if tr.HitSky then
+		return
+	end
+
+	if tr.Fraction == 1.0 then
+		return
+	end
+
+	if tr.HitNoDraw then
+		return
+	end
+
+	if !effect then          
+		effect = EffectData()
+		effect:SetOrigin( tr.HitPos )
+		effect:SetStart( tr.StartPos )
+		effect:SetSurfaceProp( tr.SurfaceProps )
+		effect:SetDamageType( iDamageType )
+		effect:SetHitBox( tr.HitBox )
+	end
+
+	if CLIENT then
+	    effect:SetEntity( tr.Entity )
+	else
+	    effect:SetEntIndex( tr.Entity:EntIndex() )
+	end
+
+	if SERVER then
+		SuppressHostEvents( ply )
+	end
+
+	if pCustomImpactName then
+		util.Effect( pCustomImpactName, effect )
+	else
+		util.Effect( "Impact", effect )
+	end
+
+	if SERVER then
+		SuppressHostEvents( NULL )
+	end
+end
+
+function util.Tracer( vecStart, vecEnd, iEntIndex, iAttachment, flVelocity, pCustomTracerName )
+
+	local data = EffectData()
+	data:SetStart( vecStart )
+	data:SetOrigin( vecEnd )
+	data:SetEntity( ents.GetByIndex( iEntIndex ) )
+	data:SetScale( flVelocity )
+	data:SetRadius( 0.1 )
+
+	if ( iAttachment ) then
+		data:SetAttachment( iAttachment )
+	end
+
+	if ( pCustomTracerName ) then
+		util.Effect( pCustomTracerName, data )
+	else
+		util.Effect( "Tracer", data )
+	end
+
+end
+
+local BulletTypeParameters = {
+	ammo_50AE = {
+		fPenetrationPower 		= 30,
+		flPenetrationDistance 	= 1000,
+	},
+	ammo_762mm = {
+		fPenetrationPower 		= 39,
+		flPenetrationDistance 	= 5000,
+	},
+	ammo_556mm = {
+		fPenetrationPower 		= 35,
+		flPenetrationDistance 	= 4000,
+	},
+	ammo_556mm_box = {
+		fPenetrationPower 		= 35,
+		flPenetrationDistance 	= 4000,
+	},
+	ammo_338mag = {
+		fPenetrationPower 		= 45,
+		flPenetrationDistance 	= 8000,
+	},
+	ammo_9mm = {
+		fPenetrationPower 		= 21,
+		flPenetrationDistance 	= 800,
+	},
+	ammo_buckshot = {
+		fPenetrationPower 		= 0,
+		flPenetrationDistance 	= 0,
+	},
+	ammo_45acp = {
+		fPenetrationPower 		= 15,
+		flPenetrationDistance 	= 500,
+	},
+	ammo_357sig = {
+		fPenetrationPower 		= 25,
+		flPenetrationDistance 	= 800,
+	},
+	ammo_57mm = {
+		fPenetrationPower 		= 30,
+		flPenetrationDistance 	= 2000,
+	},
+	default = {
+		fPenetrationPower 		= 0,
+		flPenetrationDistance 	= 0,
+	}
+}
+
+local function GetBulletTypeParameters( iBulletType )
+	local params = BulletTypeParameters[iBulletType] or BulletTypeParameters.default
+	return params.fPenetrationPower, params.flPenetrationDistance
+end
+
+local MaterialParameters = {
+	[MAT_METAL] = {
+		flPenetrationModifier 	= 0.5,
+		flDamageModifier 		= 0.3,
+	},
+	[MAT_DIRT] = {
+		flPenetrationModifier 	= 0.5,
+		flDamageModifier 		= 0.3,
+	},
+	[MAT_CONCRETE] = {
+		flPenetrationModifier 	= 0.4,
+		flDamageModifier 		= 0.25,
+	},
+	[MAT_GRATE] = {
+		flPenetrationModifier 	= 1.0,
+		flDamageModifier 		= 0.99,
+	},
+	[MAT_VENT] = {
+		flPenetrationModifier 	= 0.5,
+		flDamageModifier 		= 0.45,
+	},
+	[MAT_TILE] = {
+		flPenetrationModifier 	= 0.65,
+		flDamageModifier 		= 0.3,
+	},
+	[MAT_COMPUTER] = {
+		flPenetrationModifier 	= 0.4,
+		flDamageModifier 		= 0.45,
+	},
+	[MAT_WOOD] = {
+		flPenetrationModifier 	= 1.0,
+		flDamageModifier 		= 0.6,
+	},
+	default = {
+		flPenetrationModifier 	= 1.0,
+		flDamageModifier 		= 0.5,
+	}
+}
+
+local function GetMaterialParameters( mat )
+	local params = MaterialParameters[mat] or MaterialParameters.default
+	return params.flPenetrationModifier, params.flDamageModifier
+end
+
+local function TraceToExit( trace )
+	local flDistance = 0
+	local last = trace.vecStart
+	local vecEnd
+
+	while flDistance <= trace.flMaxDistance do
+		flDistance = flDistance + trace.flStepSize
+		vecEnd = trace.vecStart + flDistance * trace.dir
+
+		if bit.band(util.PointContents(vecEnd), MASK_SOLID) == 0 then
+			return vecEnd
+		end
+	end
+
+	return false
+end
+
+function playerMeta:MakeTracer( vecStart, vecEnd, tracerName )
+
+	-- Only show every 4 bullets
+	if self.BulletCount and self.BulletCount < 4 then
+		self.BulletCount = self.BulletCount + 1
+		return
+	else
+		self.BulletCount = 1
+	end
+
+	if CLIENT then
+
+		local vm = self:GetViewModel()
+		if IsValid(vm) then
+			local attachId = vm:LookupAttachment("1") -- css weapon are stupid
+			local attach = vm:GetAttachment( attachId )
+			vecStart = attach.Pos
+		end
+
+	end
+	
+	local data = EffectData()
+	data:SetOrigin( vecEnd )
+	data:SetStart( vecStart )
+	data:SetScale( 5000 )
+	data:SetRadius( 0.1 )
+	-- data:SetEntity( 0.1 )
+
+	if SERVER then
+		SuppressHostEvents( self )
+	end
+
+	util.Effect( tracerName or "Tracer", data )
+
+	if SERVER then
+		SuppressHostEvents( NULL )
+	end
+
+end
+
+local phys_pushscale = GetConVar( "phys_pushscale" )
+local waterContents = bit.bor( CONTENTS_WATER, CONTENTS_SLIME )
+
+function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
+	local vecSrc = bulletInfo.Src or vector_origin
+	local shootAngles = bulletInfo.Dir or vector_origin
+	local vecSpread = bulletInfo.Spread or vector_origin
+	local flDistance = bulletInfo.Distance or 56756
+	local strBulletType = ""
+	local iPenetration = 2
+	local iDamage = bulletInfo.Damage
+	local flRangeModifier = 1.0
+	local bDoEffects = true -- TODO
+
+	-- Get circular gaussian spread.
+	local x = math.Rand(-0.5, 0.5) + math.Rand(-0.5, 0.5)
+	local y = math.Rand(-0.5, 0.5) + math.Rand(-0.5, 0.5)
+
+	local fCurrentDamage = iDamage
+	local flCurrentDistance = 0.0
+
+	local vecDirShooting = shootAngles
+	local vecRight = shootAngles:Angle():Right()
+	local vecUp = shootAngles:Angle():Up()
+
+	local weap = self:GetActiveWeapon()
+	if !IsValid(weap) then return end
+
+	local iBulletType = bulletInfo.AmmoType or ""
+
+	local flDamageModifier = 0.5
+	local flPenetrationModifier = 1.0
+
+	local flPenetrationPower, flPenetrationDistance = GetBulletTypeParameters(iBulletType)
+
+	local vecDir = vecDirShooting +
+		x * vecSpread * vecRight +
+		y * vecSpread * vecUp
+
+	vecDir = vecDir:GetNormal()
+
+	local bFirstHit = true
+
+	local lastPlayerHit
+
+	while fCurrentDamage > 0 do
+		local vecEnd = vecSrc + vecDir * flDistance
+
+		local tr = util.TraceLine({
+			start = vecSrc,
+			endpos = vecEnd,
+			filter = { self, lastPlayerHit },
+			mask = bit.bor(CONTENTS_HITBOX,MASK_SOLID,CONTENTS_DEBRIS)
+		})
+
+		-- ClipTraceToPlayers?
+
+		lastPlayerHit = tr.Entity
+
+		if tr.Fraction == 1.0 then
+			break -- we didn't hit anything, stop tracing shoot
+		end
+
+		bFirstHit = false
+
+		local iEnterMaterial = tr.MatType
+
+		flPenetrationModifier, flDamageModifier = GetMaterialParameters(iEnterMaterial)
+
+		local hitGrate = bit.band(iEnterMaterial, MAT_GRATE) == MAT_GRATE
+
+		if hitGrate then
+			flPenetrationModifier = 1.0
+			flDamageModifier = 0.99
+		end
+
+		flCurrentDistance = flCurrentDistance + tr.Fraction * flDistance
+		fCurrentDamage = fCurrentDamage * math.pow(flRangeModifier, (flCurrentDistance / 500))
+
+		if flCurrentDistance > flPenetrationDistance and iPenetration > 0 then
+			iPenetration = 0
+		end
+
+		local iDamageType = bit.bor(DMG_BULLET, DMG_NEVERGIB)
+
+		if bDoEffects then
+
+			-- See if the bullet ended up underwater + started out of the water
+			if bit.band( util.PointContents(tr.StartPos), waterContents ) == 0 and
+				bit.band( util.PointContents(tr.HitPos), waterContents ) != 0 then
+
+				local waterTrace = util.TraceLine({
+					start = vecSrc,
+					endpos = tr.HitPos,
+					filter = self,
+					mask = bit.bor( MASK_SHOT, waterContents )
+				})
+
+				if waterTrace.Hit then
+
+					local data = EffectData()
+					data:SetOrigin( waterTrace.HitPos )
+					data:SetNormal( waterTrace.HitNormal )
+					data:SetScale( math.Rand(8,12) )
+					data:SetFlags( 0x0 )
+
+					-- if waterTrace.MatType == MAT_SLOSH then
+					-- 	print("water in slime")
+					-- 	data:SetFlags( 0x1 ) -- FX_WATER_IN_SLIME
+					-- end
+
+					util.Effect( "gunshotsplash", data, true, true )
+
+				end
+
+			end
+
+			-- Do regular hit effects
+			if !tr.HitSky and !tr.HitNoDraw then
+				local ent = tr.Entity
+				if !(IsValid(ent) and ent:IsPlayer() and ent:Team() == self:Team()) then
+					util.ImpactTrace(self, tr, iDamageType)
+				end
+			end
+
+			self:MakeTracer( tr.StartPos, tr.HitPos, bulletInfo.TracerName )
+
+		end
+
+		if SERVER then
+			local dmginfo = DamageInfo()
+			dmginfo:SetAttacker(self)
+			dmginfo:SetInflictor(weap)
+			dmginfo:SetDamage(fCurrentDamage)
+			dmginfo:SetDamageType(iDamageType)
+
+			dmginfo:SetDamagePosition(tr.HitPos)
+			local vecForce = vecDir:GetNormal()
+			-- vecForce = vecForce * 1 -- Ammo Damage Force
+			vecForce = vecForce * phys_pushscale:GetFloat()
+			-- vecForce = vecForce * 1 -- scale
+			dmginfo:SetDamageForce(vecForce)
+
+			tr.Entity:DispatchTraceAttack(dmginfo, tr.StartPos, tr. HitPos, vecDir)
+
+			-- TODO: TraceAttackToTriggers
+		end
+
+		if iPenetration == 0 and !hitGrate then
+			break
+		end
+
+		if iPenetration < 0 then
+			break;
+		end
+
+		local penetrationEnd = TraceToExit({
+			vecStart = tr.HitPos,
+			dir = vecDir,
+			flStepSize = 24,
+			flMaxDistance = 128
+		})
+
+		if !penetrationEnd then
+			break
+		end
+		
+		local exitTr = util.TraceLine({
+			start = penetrationEnd,
+			endpos = tr.HitPos,
+			mask = bit.bor(CONTENTS_HITBOX,MASK_SOLID,CONTENTS_DEBRIS)
+		})
+
+		if exitTr.Entity != tr.Entity and IsValid(exitTr.Entity) then
+			exitTr = util.TraceLine({
+				start = penetrationEnd,
+				endpos = tr.HitPos,
+				filter = exitTr.Entity,
+				mask = bit.bor(CONTENTS_HITBOX,MASK_SOLID,CONTENTS_DEBRIS)
+			})
+		end
+
+		local iExitMaterial = exitTr.MatType and exitTr.MatType or 0
+
+		hitGrate = hitGrate and bit.band(iExitMaterial, MAT_GRATE) == MAT_GRATE
+
+		if iEnterMaterial == iExitMaterial then
+			if iExitMaterial == MAT_WOOD or
+				iExitMaterial == MAT_METAL then
+				flPenetrationModifier = flPenetrationModifier * 2
+			end
+		end
+
+		local flTraceDistance = (exitTr.HitPos - tr.HitPos):Length()
+
+		if flTraceDistance > ( flPenetrationPower * flPenetrationModifier ) then
+			break
+		end
+
+		if bDoEffects then
+			util.ImpactTrace(self, exitTr, iDamageType)
+		end
+
+		flPenetrationPower = flPenetrationPower - flTraceDistance / flPenetrationModifier
+		flCurrentDistance = flCurrentDistance + flTraceDistance
+
+		vecSrc = exitTr.HitPos
+		flDistance = (flDistance - flCurrentDistance) * 0.5
+
+		fCurrentDamage = fCurrentDamage * flDamageModifier
+
+		iPenetration = iPenetration - 1
+
+		if isfunction(bulletInfo.Callback) then
+			bulletInfo.Callback(self, tr, dmginfo)
+		end
+	end
+
+end

--- a/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
@@ -200,7 +200,11 @@ function playerMeta:MakeTracer( vecStart, vecEnd, tracerName, tracerCount )
 		if IsValid(vm) then
 			local attachId = vm:LookupAttachment("1") -- css weapon are stupid
 			local attach = vm:GetAttachment( attachId )
-			vecStart = attach.Pos
+			if attach then
+				vecStart = attach.Pos
+			else
+				vecStart = vm:GetPos()
+			end
 		end
 
 	end

--- a/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
@@ -35,18 +35,10 @@ function util.ImpactTrace( ply, tr, iDamageType, pCustomImpactName, effect )
 	    effect:SetEntIndex( tr.Entity:EntIndex() )
 	end
 
-	if SERVER then
-		SuppressHostEvents( ply )
-	end
-
 	if pCustomImpactName then
 		util.Effect( pCustomImpactName, effect )
 	else
 		util.Effect( "Impact", effect )
-	end
-
-	if SERVER then
-		SuppressHostEvents( NULL )
 	end
 end
 
@@ -216,15 +208,7 @@ function playerMeta:MakeTracer( vecStart, vecEnd, tracerName, tracerCount )
 	data:SetRadius( 0.1 )
 	-- data:SetEntity( 0.1 )
 
-	if SERVER then
-		SuppressHostEvents( self )
-	end
-
 	util.Effect( tracerName or "Tracer", data )
-
-	if SERVER then
-		SuppressHostEvents( NULL )
-	end
 
 end
 
@@ -232,6 +216,11 @@ local phys_pushscale = GetConVar( "phys_pushscale" )
 local waterContents = bit.bor( CONTENTS_WATER, CONTENTS_SLIME )
 
 function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
+
+	if SERVER and suppressHostEvents then
+		SuppressHostEvents( self )
+	end
+
 	local vecSrc = bulletInfo.Src or vector_origin
 	local shootAngles = bulletInfo.Dir or vector_origin
 	local vecSpread = bulletInfo.Spread or vector_origin
@@ -377,7 +366,7 @@ function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
 				hook.Run( "ScaleNPCDamage", tr.Entity, tr.HitGroup, dmginfo )
 			end
 
-			tr.Entity:DispatchTraceAttack(dmginfo, tr.StartPos, tr. HitPos, vecDir)
+			tr.Entity:DispatchTraceAttack(dmginfo, tr.StartPos, tr.HitPos, vecDir)
 
 			-- TODO: TraceAttackToTriggers
 		end
@@ -450,6 +439,10 @@ function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
 		if isfunction(bulletInfo.Callback) then
 			bulletInfo.Callback(self, tr, dmginfo)
 		end
+	end
+
+	if SERVER and suppressHostEvents then
+		SuppressHostEvents( NULL )
 	end
 
 end

--- a/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_bullets.lua
@@ -1,11 +1,11 @@
--- Code taken from Breakpoint servers CS:S gamemode
+-- Code references:
+-- GM Zombie Escape gamemode
+-- https://github.com/samuelmaddock/zombie-escape
+-- Breakpoint servers CS:S gamemode
 -- https://bitbucket.org/blackops7799/breakpoint/src/bb3393586a30b99e399feca8e0d6d9e5a6fda2fc/gamemodes/css/gamemode/sh_bullets.lua
 
 local playerMeta = FindMetaTable("Player")
 if not playerMeta then return end
-
-local cTakeDamageInfoMeta = FindMetaTable("CTakeDamageInfo")
-if not cTakeDamageInfoMeta then return end
 
 function util.ImpactTrace( ply, tr, iDamageType, pCustomImpactName, effect )
 	if tr.HitSky then
@@ -245,12 +245,12 @@ function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
 	local fCurrentDamage = iDamage
 	local flCurrentDistance = 0.0
 
-	local vecDirShooting = shootAngles
+	local vecDirShooting = shootAngles:Angle():Forward()
 	local vecRight = shootAngles:Angle():Right()
 	local vecUp = shootAngles:Angle():Up()
 
 	local weap = self:GetActiveWeapon()
-	if !IsValid(weap) then return end
+	if not IsValid(weap) then return end
 
 	local iBulletType = bulletInfo.AmmoType or ""
 
@@ -263,7 +263,7 @@ function playerMeta:FireCSSBullet( bulletInfo, suppressHostEvents )
 		x * vecSpread * vecRight +
 		y * vecSpread * vecUp
 
-	vecDir = vecDir:GetNormal()
+	vecDir = vecDir:GetNormalized()
 
 	local bFirstHit = true
 

--- a/gamemodes/zombiesurvival/gamemode/sh_zombieescape.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_zombieescape.lua
@@ -130,11 +130,6 @@ hook.Add( "ShouldCollide", "CSSShouldCollide", function ( ent1, ent2 )
 		return true
 	end
 
-	-- No team collisions
-	if ent1:IsPlayer() and ent2:IsPlayer() then
-		return false
-	end
-
 end )
 
 hook.Add( "OnEntityCreated", "CSSCustomCollisions", function( ent )

--- a/gamemodes/zombiesurvival/gamemode/sh_zombieescape.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_zombieescape.lua
@@ -103,3 +103,40 @@ hook.Add( "PlayerCanPickupWeapon", "RestrictMapWeapons", function( ply, wep )
 		
 	return true
 end)
+
+hook.Add( "ShouldCollide", "CSSShouldCollide", function ( ent1, ent2 )
+
+	-- CS:S Collision Rules
+	local collisionGroup0 = ent1:GetCollisionGroup()
+	local collisionGroup1 = ent2:GetCollisionGroup()
+
+	if collisionGroup0 > collisionGroup1 then
+		local old = collisionGroup0
+		collisionGroup0 = collisionGroup1
+		collisionGroup1 = old
+	end
+
+	if collisionGroup0 == COLLISION_GROUP_PLAYER_MOVEMENT and 
+		collisionGroup1 == COLLISION_GROUP_WEAPON then
+		return false
+	end
+
+	if (collisionGroup0 == COLLISION_GROUP_PLAYER or collisionGroup0 == COLLISION_GROUP_PLAYER_MOVEMENT) and
+		collisionGroup1 == COLLISION_GROUP_PUSHAWAY then
+		return false
+	end
+
+	if collisionGroup0 == COLLISION_GROUP_DEBRIS and collisionGroup1 == COLLISION_GROUP_PUSHAWAY then
+		return true
+	end
+
+	-- No team collisions
+	if ent1:IsPlayer() and ent2:IsPlayer() then
+		return false
+	end
+
+end )
+
+hook.Add( "OnEntityCreated", "CSSCustomCollisions", function( ent )
+	ent:SetCustomCollisionCheck(true)
+end )

--- a/gamemodes/zombiesurvival/gamemode/shared.lua
+++ b/gamemodes/zombiesurvival/gamemode/shared.lua
@@ -48,6 +48,7 @@ include("sh_zombieclasses.lua")
 include("sh_animations.lua")
 include("sh_sigils.lua")
 include("sh_channel.lua")
+include("sh_bullets.lua")
 
 include("noxapi/noxapi.lua")
 


### PR DESCRIPTION
Zombie Escape maps depend on behavior only found in CS:S which can cause them to break under certain conditions in GMod. These problems are often seen in maps with bosses, pickup items, and breakable props.

I've fixed many of these problems in [my own Zombie Escape gamemode](https://github.com/samuelmaddock/zombie-escape) and I figured it might help to bring them to ZS as well.
#### Changes
- Added `GM.ShouldCollide` hook for CS:S collision rules
  - Fixes being unable to pickup weapon items
- Added custom, predicted bullet firing method which includes bullet penetration
  - Some maps require bullets to penetrate and damage `CONTENTS_GRATE` surfaces. This is often seen used on gates which players must destroy.
  - These bullets are only used in ZE maps.
- Prevented `GM.EntityTakeDamage` hook affecting breakable props in ZE since this can potentially break bosses which depend on such entities.
- Fixed entity IO which uses `SetParentAttachment` and relies on CS:S player model name attachments such as `primary`, `rfoot`, etc.
- Fixed being unable to pickup weapon items by changing their collision rules when a player attempts to pick it up.
- Added Lua `math_counter` entity to hook into logic changes such as when a boss' health changes or depletes. This can be used for [health bars](http://oi44.tinypic.com/2aim2h1.jpg) or stats.

Here's a preview of bullet penetration with a new `r_drawtracers_firstperson` convar enabled. The orb in front of the player's view is a weapon pickup in ze_ffvii_mako_reactor.
![bullet penetration](http://samuelmaddock.com/up/20160815193606_1.jpg)

It's worth saying these fixes won't resolve all problems with Zombie Escape in ZS. It seems like there's still some work that can be done around spawn timing, weapon selection, and player movement. Making the gamemode behave more like CS:S will allow the maps to play out closer to how the author intended them to.
