### PR TITLE
Fixed inventory only showing limited number of items

### DIFF
--- a/gamemodes/zombiesurvival/gamemode/inventory/client/cl_inventory.lua
+++ b/gamemodes/zombiesurvival/gamemode/inventory/client/cl_inventory.lua
@@ -352,13 +352,18 @@ function GM:OpenInventory()
 	topspace:AlignTop(8)
 	topspace:CenterHorizontal()
 
-	local invgrid = vgui.Create("DGrid", frame)
-	invgrid:SetSize(wid - 16 * screenscale, frame:GetTall() - 8 - topspace:GetTall())
-	invgrid:MoveBelow(topspace, 16)
+	local invListPanel = vgui.Create("DScrollPanel", frame)
+	invListPanel:Dock( FILL )
+	local sbar = invListPanel:GetVBar()
+	sbar.Enabled = true
+	invListPanel:DockMargin(0, topspace:GetTall() + 8, 0, 0)
+	invListPanel:InvalidateParent(true)
+
+	local invgrid = vgui.Create("DGrid", invListPanel)
+	invgrid:SetSize(invListPanel:GetWide() - sbar:GetWide(), invListPanel:GetTall())
 	invgrid:SetCols(5)
 	invgrid:SetColWide((70 + (invgrid:GetWide() - 70*5) / 4) * screenscale)
 	invgrid:SetRowHeight(70 * screenscale)
-	invgrid:CenterHorizontal()
 	frame.Grid = invgrid
 
 	for item, count in pairs(self.ZSInventory) do


### PR DESCRIPTION
Due to the lack of a scrollbar inventory will only show a limited number of items as it can be seen bellow:
![image](https://user-images.githubusercontent.com/3487334/55310032-ded4d200-5435-11e9-9002-d8aec622eb79.png)

I've placed the grid inside a DScrollPanel, here is how it looks now:
![image](https://user-images.githubusercontent.com/3487334/55310071-f3b16580-5435-11e9-9f7d-f881a3f241d6.png)


DScrollPanel also allowed me to use "Panel.Dock"  function, which allows me to use the parent component size, which enabled me to  use `Dock` and `DockMargin` instead of `setSize(wid - 16 * screenscale, frame:GetTall() - 8 - topspace:GetTall())`  