### PR TITLE
Fixed players not being able to phase when stuck inside a object

### DIFF
--- a/gamemodes/zombiesurvival/gamemode/init.lua
+++ b/gamemodes/zombiesurvival/gamemode/init.lua
@@ -3295,7 +3295,7 @@ function GM:KeyPress(pl, key)
 			else
 				local plvel = pl:GetVelocity()
 				if pl:GetPhysicsObject():IsPenetrating() then
-					if plvel == vector_origin then
+					if (plvel.x == 0 and plvel.y == 0 and (plvel.z == -4.5 or plvel.z == 0)) then
 						pl.LastGhostFailureVelocity = nil
 						pl:SetBarricadeGhosting(true)
 					else


### PR DESCRIPTION
When stuck inside a object players' z axis velocity stay fixed at  -4.500000, making it seem like he's moving when he's not.