### PR TITLE
Weapon quality fix for latest update

### DIFF
--- a/gamemodes/zombiesurvival/gamemode/sh_weaponquality.lua
+++ b/gamemodes/zombiesurvival/gamemode/sh_weaponquality.lua
@@ -182,6 +182,7 @@ function GM:CreateWeaponOfQuality(i, orig, quality, classname, branch)
 		local afent = scripted_ents.Get((prefix or "") .. class)
 		if cbk then cbk(afent, newent) end
 
+		afent.ClassName = nil
 		scripted_ents.Register(afent, (prefix or "") .. newent)
 		return newent
 	end
@@ -219,6 +220,7 @@ function GM:CreateWeaponOfQuality(i, orig, quality, classname, branch)
 		ent.GhostWeapon = newclass
 	end, "status_") end
 
+	wept.ClassName = nil
 	weapons.Register(wept, newclass)
 end
 


### PR DESCRIPTION
A bug was introduced into ZS because if this commit: https://github.com/Facepunch/garrysmod/commit/71a181f9220ec19f63aaa7da00a318a9b11c0b6b ClassName variables on the table to be registered are favored over the one given explicitly and this will fix that.