### PR TITLE
Fix medical kit resets cooldown by discarding all ammo before firing

### DIFF
--- a/gamemodes/zombiesurvival/entities/weapons/weapon_zs_medicalkit.lua
+++ b/gamemodes/zombiesurvival/entities/weapons/weapon_zs_medicalkit.lua
@@ -171,7 +171,6 @@ function SWEP:CanPrimaryAttack()
 	if self:GetPrimaryAmmoCount() <= 0 then
 		self:EmitSound("items/medshotno1.wav")
 
-		owner.NextMedKitUse = self:GetNextCharge()
 		return false
 	end
 

--- a/gamemodes/zombiesurvival/entities/weapons/weapon_zs_medicalkit.lua
+++ b/gamemodes/zombiesurvival/entities/weapons/weapon_zs_medicalkit.lua
@@ -171,7 +171,6 @@ function SWEP:CanPrimaryAttack()
 	if self:GetPrimaryAmmoCount() <= 0 then
 		self:EmitSound("items/medshotno1.wav")
 
-		self:SetNextCharge(CurTime() + 0.75)
 		owner.NextMedKitUse = self:GetNextCharge()
 		return false
 	end

--- a/gamemodes/zombiesurvival/entities/weapons/weapon_zs_medicalkit.lua
+++ b/gamemodes/zombiesurvival/entities/weapons/weapon_zs_medicalkit.lua
@@ -171,6 +171,7 @@ function SWEP:CanPrimaryAttack()
 	if self:GetPrimaryAmmoCount() <= 0 then
 		self:EmitSound("items/medshotno1.wav")
 
+		self:SetNextCharge(CurTime() + 0.75)
 		return false
 	end
 
@@ -188,8 +189,9 @@ function SWEP:DrawHUD()
 	local wid, hei = 384, 16
 	local x, y = ScrW() - wid - 32, ScrH() - hei - 72
 	local texty = y - 4 - draw.GetFontHeight("ZSHUDFontSmall")
+	local owner = self:GetOwner()
 
-	local timeleft = self:GetNextCharge() - CurTime()
+	local timeleft = (owner.NextMedKitUse or self:GetNextCharge()) - CurTime()
 	if 0 < timeleft then
 		surface.SetDrawColor(5, 5, 5, 180)
 		surface.DrawRect(x, y, wid, hei)


### PR DESCRIPTION
Fix medical kit resets cooldown by discarding all ammo before firing