### PR TITLE
Support L4D-/CSGO-style door gibbing

### DIFF
--- a/gamemodes/zombiesurvival/gamemode/init.lua
+++ b/gamemodes/zombiesurvival/gamemode/init.lua
@@ -914,11 +914,6 @@ local function getDoorHitSoundsFromModel(mdl)
 	-- Also removes the extracted key from the `doorOptions` table to avoid wasteful
 	-- iteration later on
 	defaultBlock, doorOptions["defaults"] = doorOptions["defaults"], nil
-	if not defaultBlock then
-		-- It appears these KVs can also be stored in the "default" block, so check that
-		-- if "defaults" was absent
-		defaultBlock, doorOptions["default"] = doorOptions["default"], nil
-	end
 
 	if defaultBlock and defaultBlock["pound"] then
 		result[-1] = defaultBlock["pound"]

--- a/gamemodes/zombiesurvival/gamemode/obj_entity_extend_sv.lua
+++ b/gamemodes/zombiesurvival/gamemode/obj_entity_extend_sv.lua
@@ -7,8 +7,21 @@ function meta:SetCollisionGroup(g)
 	o(self, g)
 end]]
 
+--[[
+	From the Garry's Mod Wiki (https://wiki.facepunch.com/gmod/Entity:GetSaveTable):
+
+	It is highly recommended to use Entity:GetInternalVariable for retrieving a single
+	key of the save table for performance reasons.
+--]]
+
 function meta:IsDoorLocked()
-	return self:GetSaveTable().m_bLocked
+	return self:GetInternalVariable("m_bLocked")
+end
+
+-- Figured "Natively" is a must when just about everything in this gamemode is destructible
+-- but through self-implemented means (not mechanics "native" to the game engine)
+function meta:IsDoorNativelyBreakable()
+	return self:GetInternalVariable("m_bBreakable") -- This can also change through entity I/O
 end
 
 function meta:HealPlayer(pl, amount, pointmul, nobymsg, poisononly)

--- a/gamemodes/zombiesurvival/gamemode/sv_options.lua
+++ b/gamemodes/zombiesurvival/gamemode/sv_options.lua
@@ -105,6 +105,11 @@ cvars.AddChangeCallback("zs_repairpointsperhealth", function(cvar, oldvalue, new
 	GAMEMODE.RepairPointsPerHealth = tonumber(newvalue) or 1
 end)
 
+GM.OnlyUndeadCanGibDoors = CreateConVar("zs_onlyzombiescangibdoors", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY, "Specifies only the undead can gib doors marked as breakable (L4D-style doors)."):GetBool()
+cvars.AddChangeCallback("zs_onlyzombiescangibdoors", function(cvar, oldvalue, newvalue)
+	GAMEMODE.OnlyUndeadCanGibDoors = tobool(newvalue)
+end)
+
 local function GetMostKey(key, top)
 	top = top or 0
 	local toppl


### PR DESCRIPTION
# Summary

Later Source games (most notably, _L4D_, _L4D2_ and _CS:GO_) implemented support for [breakable `prop_door_rotating` door models](https://developer.valvesoftware.com/wiki/Prop_door_rotating#L4D_Series_Doors). Sometime in the last year or two, _Garry's Mod_ received support for this behavior.

As breakability of doors is a feature traditionally implemented in Lua by Zombie Survival for earlier Source games' *un*breakable door models, using doors with these newer features effectively creates a situation where doors can't be used for barricading (attempting to turn a door into a prop by damaging it will result in the door's complete destruction, always).

As it stands, using door models compiled with these special options elicits no special behavior in Zombie Survival (other than disintegrating when busted down). With these changes, I aimed to implement `prop_door_rotating`'s native gibbing feature in a way that seemed most palatable to the "goal" of the gamemode, creating the least disturbance to existing game mechanics as reasonably possible:

# [Video Demonstration](https://www.youtube.com/watch?v=hqc2SNrZzo4)

# Change Notes

- By default, only damage from zombies will cause gibbing/destruction of doors
  - This is achieved by disabling the door's breakable status (`m_bBreakable`) before the damage event takes place and restoring it afterwards
  - Includes a `zs_onlyzombiescangibdoors` ConVar, allowing server operators to optionally lift the restriction on damage sources
- Undead door-hitting sounds are overridden on door models with `"pound"` KVs in their `$keyvalues`' `"door_options"` blocks
  - This can also be overridden on a skin-by-skin basis, as with other `"door_options"` KVs
  - Door information is populated:
    - Within `GM:InitPostEntityMap` (for all doors present in the map)
    - On a door-by-door basis in `GM:EntityTakeDamage`, _only_ if they are found to lack the `m_DoorOriginalModel` key populated by `GM:SetupBreakablePropDoor`

## P.S.

### `meta:IsDoorLocked`
I made a minor modification to `meta:IsDoorLocked` (`obj_entity_extend_sv.lua`, line 18), changing `self:GetSaveTable().m_bLocked` to `self:GetInternalVariable("m_bLocked")`. Given that `Entity:GetSaveTable` populates its return table with _all_ save table values for _each_ new call, `Entity:GetInternalVariable(...)` should be much more performant for the task (according to its [wiki page](https://wiki.facepunch.com/gmod/Entity:GetSaveTable)).

As an optimization it was simple to implement, a marked improvement and proximal enough to what I was doing already to make me feel as though it was worth including; I wouldn't be making such a big deal of pointing it out were it not technically outside of the scope of this request.

### Concerning the Door Models Themselves
_Garry's Mod_'s `studiomdl.exe` also supports these features now, so it's not unreasonable to assume new maps will start popping up with custom door models that support them (even excluding those ripped from _L4D/L4D2/CS:GO_).