### PR TITLE
Fix entity outputs on all new Garry's Mod maps (`meta:AddOnOutput`)

### DIFF
--- a/gamemodes/zombiesurvival/gamemode/obj_entity_extend_sv.lua
+++ b/gamemodes/zombiesurvival/gamemode/obj_entity_extend_sv.lua
@@ -219,7 +219,14 @@ end
 
 function meta:AddOnOutput(key, value)
 	self[key] = self[key] or {}
-	local tab = string.Explode(",", value)
+
+	-- Newer Source Engine games use this symbol as a delimiter
+	local tab = string.Explode("\x1B", value)
+	-- Fall back to comma-delimited array when necessary
+	if (#tab < 2) then
+		tab = string.Explode(",", value)
+	end
+
 	table.insert(self[key], {entityname=tab[1], input=tab[2], args=tab[3], delay=tab[4], reps=tab[5]})
 end
 


### PR DESCRIPTION
# TLDR

As it stands [without this fix], literally 100% of maps compiled with Garry's Mod's tools can't use the outputs on any of the entities this gamemode implements (such as `logic_waves`, `logic_classunlock`, `logic_winlose`, etc.; any entities that use the `meta:AddOnOutput` and `meta:FireOutput` system).

# Summary

Any maps compiled with Garry's Mod's tools since around a year ago (I think, not certain about the timeline) use a different character for delimiting key values and entity I/O data. This needs to be accounted for.

I used a snippet from Garry's Mod's native `ENTITY:StoreOutput` whilst preserving the surrounding logic to ensure nothing else changes or breaks.

Entities like `logic_waves` which were previously 100% dysfunctional on maps compiled with newer tool versions are now functional again.