### PR TITLE
Fix the duplicate hook identifier

### DIFF
--- a/gamemodes/zombiesurvival/gamemode/statistics/server/sv_statistics.lua
+++ b/gamemodes/zombiesurvival/gamemode/statistics/server/sv_statistics.lua
@@ -9,7 +9,7 @@ STATTRACK_TYPE_ZOMBIECLASS = 2
 STATTRACK_TYPE_ROUND = 3
 STATTRACK_TYPE_SKILL = 4
 
-hook.Add("Initialize", "ZSProfiler", function()
+hook.Add("Initialize", "ZSStatTrack", function()
 	file.CreateDir(stattrack.Folder)
 
 	for _, map in pairs({"tantibus", "serious_sam", "gauntlet", "high_noon", "croak"}) do


### PR DESCRIPTION
This caused broken functionality with editing the sigil placement with sigilplacer in the gamemode by default.

Fixed by renaming the "ZSProfiler" hook to "ZSStatTrack" to prevent the ZSProfiler hook (sv_profiling) from being overridden.

With this little fix, the default "zsprofiler" and "profiler_premade" data directories should be created automatically on startup, which allows to edit sigils on maps between sessions without having to manually create the said directories as intended.